### PR TITLE
Better certificate generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@
 *.pem
 *.srl
 
-# Local
+# Local .env configuration
 .env
+
+# Here are the local configurations like certificates and more later
+etc/

--- a/README.md
+++ b/README.md
@@ -2,14 +2,35 @@
 
 ## Installation
 
+### .env file
+
+Copy and adjust `containers/.env.example` to `containers/.env`
+
+```
+cp containers/.env.example containers/.env
+```
+
+### Generate SSL certificate
+
 Create certificates for HTTPS
 ```bash
-chmod u+x ./scripts/generate-certificates.sh
 ./scripts/generate-certificates.sh
 ```
-You need to add the generated certificate `certificates/docker.rootCA.crt` to your browser authorities and trust related websites.
+You need to add the generated certificate `etc/certificates/pontsun.rootCA.crt` to your browser authorities and trust related websites.
 
-Start Traefik and Portainer
+If you have [step-cli](https://smallstep.com/docs/cli/) or are on OS X, this should happen automatically.
+
+### Setup local DNS 
+
+See
+
+- [Docker installation for Mac](docs/docker-installation-for-mac.md)
+- [Docker installation for Ubuntu](docs/docker-installation-for-ubuntu.md)
+
+for now.
+
+###  Start pontsun with traefik and portainer
+
 ```bash
 cd containers
 docker-compose up -d

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $DIR
+docker build -t liip/pontsun-helper:latest helper

--- a/build/helper/Dockerfile
+++ b/build/helper/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.10
+
+RUN set -ex; \
+    # Install Bash and OpenSSL
+    apk add --no-cache bash openssl

--- a/config/openssl.cnf
+++ b/config/openssl.cnf
@@ -11,5 +11,3 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectAltName = @alt_names
 
 [ alt_names ]
-DNS.1 = ${ENV::PROJECT_NAME}.${ENV::PROJECT_EXTENSION}
-DNS.2 = *.${ENV::PROJECT_NAME}.${ENV::PROJECT_EXTENSION}

--- a/containers/.env.example
+++ b/containers/.env.example
@@ -1,5 +1,4 @@
 ### Project settings
-
 COMPOSE_PROJECT_NAME=traefik
 PROJECT_NAME=pontsun
 PROJECT_EXTENSION=test
@@ -11,6 +10,9 @@ PONTSUN_HTTPS_PORT=443
 
 # name of the docker network used for pontsun
 PONTSUN_NETWORK=pontsun
+
+# Where to store local config files, could also be ~/.pontsun
+PONTSUN_DIR_ETC=../etc
 
 ### Images tags
 PORTAINER_TAG=1.19.2

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - '${PONTSUN_HTTP_PORT}:80'
       - '${PONTSUN_HTTPS_PORT}:443'
     volumes:
-      - ../certificates/:/certs/
+      - ${PONTSUN_DIR_ETC:-../etc/}/certificates/:/certs/
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - 'traefik.enable=true'

--- a/scripts/helper/docker-generate-certificates.sh
+++ b/scripts/helper/docker-generate-certificates.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -e
+
+# Load env file
+set -a
+test -f $(dirname $0)/../../containers/.env && source $(dirname $0)/../../containers/.env
+set +a
+
+# check if there are certs in the local directory
+cd /certs/
+if [ -f $PROJECT_NAME.crt ] && [ -z $1 ]; then
+    echo "Certificate already exists in local certificates directory."
+else
+    if [ -f $PROJECT_NAME.crt ]; then
+        # get existing alt names from the current cert, so that we can reuse them
+        EXISTING_ALT_NAMES=$(certtool -i < /certs/$PROJECT_NAME.crt  | grep DNSname | cut -f 2 -d ":"  | sed -e 's/^[[:space:]]*//')
+        ALT_NAMES=${EXISTING_ALT_NAMES}
+    else
+        ALT_NAMES=$PROJECT_NAME.$PROJECT_EXTENSION
+        ALT_NAMES=${ALT_NAMES}$'\n'*.$PROJECT_NAME.$PROJECT_EXTENSION
+    fi
+    # add additional altnames
+    if [[ ! -z $1 ]]; then
+        ALT_NAMES=${ALT_NAMES}$'\n'$1
+        ALT_NAMES=${ALT_NAMES}$'\n'*.$1
+    fi
+
+    # sort them and make them uniq to avoid duplicates
+    ALT_NAMES=$(echo $"${ALT_NAMES}" | sort | uniq)
+    EXISTING_ALT_NAMES=$(echo $"${EXISTING_ALT_NAMES}" | sort | uniq)
+
+    if [[ $ALT_NAMES == $EXISTING_ALT_NAMES ]]; then
+        echo "Certificate wouldn't change, don't generate a new one."
+        exit 0;
+    fi
+
+    I=1
+    #write the correct config lines
+    while read -r line; do
+        if [[ ! -z $line ]]; then
+        ALT_NAMES_CONFIG=$ALT_NAMES_CONFIG$'\n'"DNS.$I = $line"
+        ((I++))
+        fi
+    done <<< "$ALT_NAMES"
+
+    subj="/C=CH/ST=FR/L=Fribourg/O=Liip/CN=$PROJECT_NAME.$PROJECT_EXTENSION"
+    # don't regenerate rootCA, if it already exists
+    if [ ! -f $PROJECT_NAME.rootCA.key ]; then
+        openssl genrsa -out $PROJECT_NAME.rootCA.key 4096
+        openssl req -x509 -new -nodes -key $PROJECT_NAME.rootCA.key -sha256 -days 1024 -out $PROJECT_NAME.rootCA.crt -subj "$subj"
+    fi
+    openssl genrsa -out $PROJECT_NAME.key 4096
+    openssl req -new -sha256 -subj "$subj" -key $PROJECT_NAME.key -out $PROJECT_NAME.csr -config  <(cat /generate/config/openssl.cnf <(printf "$ALT_NAMES_CONFIG"))
+    openssl x509 -req -in $PROJECT_NAME.csr -CA $PROJECT_NAME.rootCA.crt -CAkey $PROJECT_NAME.rootCA.key -CAcreateserial -out $PROJECT_NAME.crt -days 365 -extensions v3_req -extfile  <(cat /generate/config/openssl.cnf <(printf "$ALT_NAMES_CONFIG"))
+
+    cat $PROJECT_NAME.crt $PROJECT_NAME.key > $PROJECT_NAME.pem
+    chmod 600 $PROJECT_NAME.key $PROJECT_NAME.pem
+fi
+

--- a/scripts/helper/env.sh
+++ b/scripts/helper/env.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+PONTSUN_DIR_REL=${PONTSUN_DIR:-$DIR/../../}
+PONTSUN_DIR="$( cd ${PONTSUN_DIR_REL} && pwd )"
+PONTSUN_DIR_ETC=${PONTSUN_DIR_ETC:-$PONTSUN_DIR/etc/}
+
+# Load env file
+set -a
+# load env variables but only if not set already
+
+if [[ ! -f $PONTSUN_DIR/containers/.env ]]; then
+  RED='\033[0;31m'
+  NC='\033[0m' # No Color
+
+  printf "${RED}${PONTSUN_DIR}/containers/.env does not exist!${NC}\nPlease copy it with:\n"
+  printf "cp ${PONTSUN_DIR}/containers/.env.example ${PONTSUN_DIR}/containers/.env\n"
+  printf  "and adjust it.\n"
+  exit 1
+fi
+test -f $PONTSUN_DIR/containers/.env && source <(grep -v '^\s*#' $PONTSUN_DIR/containers/.env | sed -E 's|^ *([^=]+)=(.*)$|: ${\1=\2}; export \1|g')
+

--- a/scripts/helper/install-cert-macos.sh
+++ b/scripts/helper/install-cert-macos.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# base from https://gist.github.com/koop/84254d5214495e6fc49db3284c9b7772
+# Usage
+# $ ./install-cert-macos.sh "/path/to/cert"
+
+CERT_PATH=$1
+
+# First, grab the SHA-1 from the provided SSL cert.
+CERT_SHA1=$(openssl x509 -in "$CERT_PATH" -sha1 -noout -fingerprint | cut -d "=" -f2 | sed "s/://g")
+
+# Next, grab the SHA-1s of any standard.dev certs in the keychain.
+# Don't return an error code if nothing is found.
+EXISTING_CERT_SHAS=$(security find-certificate -a -c "$PROJECT_NAME.$PROJECT_EXTENSION" -Z /Library/Keychains/System.keychain | grep "SHA-1") || true
+echo "$EXISTING_CERT_SHAS" | grep -q "$CERT_SHA1" || {
+  echo "Installing $CERT_PATH into your Keychain"
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CERT_PATH"
+}


### PR DESCRIPTION
Initial problem: The certificate generation doesn't work on OS X, since openssl behaves differently (it errors out)

Solution: Use a docker image to generate to certificates on all platforms. Also to make the environment consistent.

Problem 2: If you want to have an additional domain name other than the default one for your project (let's say, api.rokka.test instead of rokka-api.pontsun.test), there was no easy way. 

Solution 2: Add alternate DNS entries to the cert. The script now reads all the existing and adds new one before recreating it.

More stuff in this MR:

- Moved certificates from `certificates/` to `etc/certificates` to be able to have more config options in that directory (it's configurable via the PONTSUN_DIR_ETC variable)

- Automatically installs the generated root certificate to the system trust store on OS X or if smallstep-cli is installed (https://smallstep.com/docs/cli/), if it doesn't exist already (needs password)

The helper image (liip/pontsun-helper:latest) for openssl cert generation isn't on hub.docker.com yet (I need to get the credentials before I can upload it), you have to generate it first locally with `build/build.sh`