### PR TITLE
Validity Period for Mac OS Catalina (10.15.x)

### DIFF
--- a/containers/docker-compose.certificates.yml
+++ b/containers/docker-compose.certificates.yml
@@ -6,6 +6,7 @@ services:
       container_name: 'pontsun_ssl-keygen'
       command: ls
       environment:
+          OPENSSL_CERTIFICATE_EXPIRATION: 825
           OPENSSL_CERTIFICATE_SUBJECT_COUNTRY: CH
           OPENSSL_CERTIFICATE_SUBJECT_STATE: FR
           OPENSSL_CERTIFICATE_SUBJECT_LOCATION: Fribourg


### PR DESCRIPTION
Stumbled across an issue where the certificate has been added to keychain and while trusted, still getting refused in chrome.

According to this [article](https://support.apple.com/en-us/HT210176): 

> TLS server certificates must have a validity period of 825 days or fewer (as expressed in the NotBefore and NotAfter fields of the certificate).

Apple has changed its policies for certificates, which is exceeded by the default value of `OPENSSL_CERTIFICATE_EXPIRATION` in the [ssl-keygen](https://github.com/liip/docker-ssl-keygen)

