### PR TITLE
Migrate Traefik config to v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@
 *.pem
 *.srl
 
+# Traefik config
+docker-compose.custom.yml
+config/*.yml
+
 # Local
 .env

--- a/README.md
+++ b/README.md
@@ -26,10 +26,18 @@ Adapt the `./containers/.env` file as needed.
 
 ### Create certificates for HTTPS
 
+Create the certificates:
 ```sh
 cd containers/
 USER_ID=$(id -u) docker-compose -p pontsun_sslkeygen -f docker-compose.certificates.yml up
 ```
+
+Then copy the traefik config:
+```sh
+cd ..
+cp config/pontsun.yml.dist config/pontsun.yml
+```
+(You will need to tweak it if your local domain is not `docker.test`)
 
 You can add the fake root CA authority certificate `certificates/docker.test.rootCA.crt`
 to your browser authorities in order to let it trust the concerned local development instances.

--- a/config/pontsun.yml.dist
+++ b/config/pontsun.yml.dist
@@ -1,0 +1,12 @@
+http:
+  middlewares:
+    https_redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true
+tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /certs/docker.test.crt
+        keyFile: /certs/docker.test.key

--- a/containers/.env.example
+++ b/containers/.env.example
@@ -16,7 +16,7 @@ PONTSUN_NETWORK=pontsun
 # https://hub.docker.com/r/portainer/portainer
 PORTAINER_TAG=1.22.1
 # https://hub.docker.com/_/traefik
-TRAEFIK_TAG=2.2
+TRAEFIK_TAG=2.8
 # https://hub.docker.com/r/docksal/ssh-agent
 SSH_AGENT_TAG=1.3
 # https://hub.docker.com/r/liip/ssl-keygen

--- a/containers/.env.example
+++ b/containers/.env.example
@@ -1,8 +1,7 @@
 ### Project settings
 
 COMPOSE_PROJECT_NAME=pontsun
-PROJECT_NAME=docker
-PROJECT_EXTENSION=test
+PROJECT_NAME=pontsun
 PROJECT_DOMAIN=docker.test
 
 # Used ports for traefik
@@ -17,7 +16,7 @@ PONTSUN_NETWORK=pontsun
 # https://hub.docker.com/r/portainer/portainer
 PORTAINER_TAG=1.22.1
 # https://hub.docker.com/_/traefik
-TRAEFIK_TAG=1.7.18-alpine
+TRAEFIK_TAG=2.2
 # https://hub.docker.com/r/docksal/ssh-agent
 SSH_AGENT_TAG=1.3
 # https://hub.docker.com/r/liip/ssl-keygen

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -2,51 +2,56 @@ version: '3.5'
 services:
 
   traefik:
-    image: traefik:$TRAEFIK_TAG
-    container_name: pontsun_traefik
-    command: -c /dev/null \
-      --api \
-      --api.dashboard=true \
-      --docker \
-      --docker.domain='${PROJECT_NAME}.${PROJECT_EXTENSION}' \
-      --docker.watch=true \
-      --docker.exposedByDefault=false \
-      --defaultEntryPoints='https' \
-      --defaultEntryPoints='http' \
-      --rootCAs='/certs/${PROJECT_DOMAIN}.rootCA.crt' \
-      --entryPoints='Name:http Address::80' \
-      --entryPoints='Name:https Address::443 TLS:/certs/${PROJECT_DOMAIN}.crt,/certs/${PROJECT_DOMAIN}.key' \
-      --logLevel=ERROR
+    image: traefik:${TRAEFIK_TAG}
+    container_name: ${PROJECT_NAME}_traefik
+    environment:
+      TRAEFIK_API: 'true'
+      TRAEFIK_API_DASHBOARD: 'true'
+      TRAEFIK_API_INSECURE: 'true'
+      TRAEFIK_ENTRYPOINTS_HTTP: 'true'
+      TRAEFIK_ENTRYPOINTS_HTTP_ADDRESS: ':${PONTSUN_HTTP_PORT}'
+      TRAEFIK_ENTRYPOINTS_HTTPS: 'true'
+      TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS: ':${PONTSUN_HTTPS_PORT}'
+      TRAEFIK_ENTRYPOINTS_HTTPS_HTTP_TLS: 'true'
+      TRAEFIK_GLOBAL_SENDANONYMOUSUSAGE: 'false'
+      TRAEFIK_LOG_LEVEL: ERROR
+      TRAEFIK_PROVIDERS_DOCKER: 'true'
+      TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE: Host(`{{ trimPrefix `/` .Name }}.${PROJECT_DOMAIN}`)
+      TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT: 'false'
+      TRAEFIK_PROVIDERS_DOCKER_NETWORK: ${PONTSUN_NETWORK}
+      TRAEFIK_PROVIDERS_FILE_DIRECTORY: /etc/traefik/dynamic/
+      TRAEFIK_SERVERSTRANSPORT_ROOTCAS: /certs/${PROJECT_DOMAIN}.rootCA.crt
     restart: always
     ports:
       - '${PONTSUN_HTTP_PORT}:80'
       - '${PONTSUN_HTTPS_PORT}:443'
     volumes:
-      - ../certificates/:/certs/
+      - ../config/:/etc/traefik/dynamic/
+      - ../certificates/:/certs/:ro
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - 'traefik.enable=true'
-      - 'traefik.port=8080'
-      - 'traefik.frontend.rule=Host:traefik.${PROJECT_NAME}.${PROJECT_EXTENSION}'
-      - 'traefik.frontend.headers.SSLRedirect=true' #always redirect to https
+      - 'traefik.http.routers.${PROJECT_NAME}_traefik.entrypoints=http, https'
+      - 'traefik.http.routers.${PROJECT_NAME}_traefik.rule=Host(`traefik.${PROJECT_DOMAIN}`)'
+      - 'traefik.http.services.${PROJECT_NAME}_traefik.loadbalancer.server.port=8080'
     networks:
       - pontsun
 
   portainer:
-    image: portainer/portainer:$PORTAINER_TAG
-    container_name: pontsun_portainer
+    image: portainer/portainer:${PORTAINER_TAG}
+    container_name: ${PROJECT_NAME}_portainer
     restart: unless-stopped
     command: --no-auth -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - 'traefik.enable=true'
-      - 'traefik.port=9000'
-      - 'traefik.frontend.rule=Host:portainer.${PROJECT_NAME}.${PROJECT_EXTENSION}'
-      - 'traefik.frontend.headers.SSLRedirect=true' #always redirect to https
+      - 'traefik.http.routers.${PROJECT_NAME}_portainer.entrypoints=http, https'
+      - 'traefik.http.routers.${PROJECT_NAME}_portainer.rule=Host(`portainer.${PROJECT_DOMAIN}`)'
+      - 'traefik.http.services.${PROJECT_NAME}_portainer.loadbalancer.server.port=9000'
     networks:
       - pontsun
 
 networks:
   pontsun:
-    name: $PONTSUN_NETWORK
+    name: ${PONTSUN_NETWORK}


### PR DESCRIPTION
Traefik v2 introduces many new very interesting features, TCP amongst them.

Please note that migrating to Traefik v2 introduces many breaking changes and will require an update of the Pontsun config and all projects based on Pontsun.

To update the Pontsun repo, simply copy and adapt if needed the config and restart the containers:
```sh
cp config/pontsun.yml.dist config/pontsun.yml
```
This step is required as the certificates can no longer be declared with the static config.

To update projects you can follow the [official migration page](https://docs.traefik.io/migration/v1-to-v2/). As an example, this nginx config in v1:
```yaml
labels:
      - 'traefik.enable=true'
      - 'traefik.docker.network=pontsun'
      - 'traefik.backend=${PROJECT_NAME}_nginx'
      - 'traefik.port=8080'
      - 'traefik.frontend.rule=Host:${PROJECT_NAME}.${PROJECT_DOMAIN}'
      - 'traefik.frontend.headers.SSLRedirect=true'
```
Will be in v2:
```yaml
labels:
      - 'traefik.enable=true'
      - 'traefik.http.routers.${PROJECT_NAME}_nginx.entrypoints=http, https'
      - 'traefik.http.routers.${PROJECT_NAME}_nginx.middlewares=https_redirect@file'
      - 'traefik.http.routers.${PROJECT_NAME}_nginx.rule=Host(`${PROJECT_NAME}.${PROJECT_DOMAIN}`)'
      - 'traefik.http.services.${PROJECT_NAME}_nginx.loadbalancer.server.port=8080'
```

I also added `docker-compose.custom.yml` to the ignored files to propose a default filename for Pontsun config overwrite like declaring new entrypoints or providing a traefik config file.
