### PR TITLE
Dnsmasq dedicated container

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ cd containers
 docker-compose up -d
 ```
 
+### With Dnsmasq
+
+To use a Dnsmasq container rather than installing it, start Pontsun with
+
+```sh
+cd containers
+docker-compose -f docker-compose.yml -f docker-compose.dnsmasq.yml up -d
+```
+
+You can also add the following to your `containers/.env` file instead
+
+```dotenv
+COMPOSE_FILE=docker-compose.yml:docker-compose.dnsmasq.yml
+```
+
 ### With SSH agent
 
 #### Linux
@@ -74,7 +89,7 @@ docker-compose -f docker-compose.yml -f docker-compose.ssh-agent.yml up -d
 
 You can also add the following to your `containers/.env` file instead
 
-```
+```dotenv
 COMPOSE_FILE=docker-compose.yml:docker-compose.ssh-agent.yml
 ```
 

--- a/containers/.env.example
+++ b/containers/.env.example
@@ -6,6 +6,7 @@ PROJECT_EXTENSION=test
 PROJECT_DOMAIN=docker.test
 
 # Used ports for traefik
+PONTSUN_DNS_PORT=53
 PONTSUN_HTTP_PORT=80
 PONTSUN_HTTPS_PORT=443
 
@@ -14,6 +15,8 @@ PONTSUN_NETWORK=pontsun
 
 ### Images tags
 
+# https://hub.docker.com/r/liip/dnsmasq
+DNSMASQ_TAG=1.0.0
 # https://hub.docker.com/r/portainer/portainer
 PORTAINER_TAG=1.22.1
 # https://hub.docker.com/_/traefik

--- a/containers/docker-compose.dnsmasq.yml
+++ b/containers/docker-compose.dnsmasq.yml
@@ -1,0 +1,16 @@
+version: '3.5'
+services:
+
+  dnsmasq:
+    image: liip/dnsmasq:${DNSMASQ_TAG}
+    container_name: pontsun_dnsmasq
+    restart: always
+    environment:
+      DNSMASQ_DEFAULT_DOMAIN: ${PROJECT_DOMAIN}
+    logging:
+      options:
+        max-size: 20m
+    ports:
+      - '${PONTSUN_DNS_PORT}:5353/udp'
+    networks:
+      - pontsun

--- a/docs/installation-for-debian.md
+++ b/docs/installation-for-debian.md
@@ -16,6 +16,14 @@ Follow the installation procedure: [https://docs.docker.com/compose/install/](ht
 
 ## Dnsmasq
 
+You can either use the Dnsmasq container or install it locally.
+
+### Option A: Container
+
+To use the Dnsmasq container follow the [README instructions](../README.md#with-dnsmasq).
+
+### Option B: Local installation
+
 Dnsmasq will automatically forward any **\*.docker.test** domain to our
 local docker infrastructure.
 

--- a/docs/installation-for-mac.md
+++ b/docs/installation-for-mac.md
@@ -35,6 +35,20 @@ gem install docker-sync
 Dnsmasq will automatically forward any **\*.docker.test** domain to our
 local docker infrastructure.
 
+You can either use the Dnsmasq container or install it locally.
+
+Either way, you will also need the create the resolver
+```
+sudo mkdir -v /etc/resolver
+sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/docker.test'
+```
+
+### Option A: Container
+
+To use the Dnsmasq container follow the [README instructions](../README.md#with-dnsmasq).
+
+### Option B: Local installation
+
 Install Dnsmasq
 ```
 brew install dnsmasq
@@ -51,12 +65,6 @@ Start Dnsmasq on every startup and launch it now
 ```
 sudo cp -v $(brew --prefix dnsmasq)/homebrew.mxcl.dnsmasq.plist /Library/LaunchDaemons
 sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.dnsmasq.plist
-```
-
-Create resolver
-```
-sudo mkdir -v /etc/resolver
-sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/docker.test'
 ```
 
 ## Trust certificates (to be done AFTER Pontsun install)


### PR DESCRIPTION
This pull request follows and replaces PR https://github.com/liip/pontsun/pull/8.

It proposes to use a dnsmasq container instead of installing it locally for those interested.

External resources:
- [Dnsmasq dockerhub page](https://hub.docker.com/r/liip/dnsmasq)
- [Dnsmasq github repository](https://github.com/liip/docker-dnsmasq)