### PR TITLE
New SSH agent with persistent keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,19 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.ssh-agent.yml
 ##### Add your ssh keys
 
 ```sh
+SSH_DIR=~/.ssh
 KEY=id_rsa
-docker run --rm --volumes-from=pontsun_sshagent -v ~/.ssh/$KEY:/root/.ssh/$KEY -it docksal/ssh-agent:latest ssh-add /root/.ssh/$KEY
+docker run \
+    --rm \
+    --volumes-from=pontsun_sshagent \
+    -v ${SSH_DIR}/${KEY}:/.ssh/${KEY} \
+    -it \
+    docker.gitlab.liip.ch/docker/ssh-agent:1.0.0 \
+    ssh-key add ${KEY}
 ```
 
-As the key is stored in memory, you need to add it every time the SSH agent container is restarted.
+The keys are stored in a named volume, as long as this volume is not destroyed,
+keys will be loaded automatically on container startup.
 
 ##### Update your docker-compose
 

--- a/containers/.env.example
+++ b/containers/.env.example
@@ -18,7 +18,7 @@ PONTSUN_NETWORK=pontsun
 PORTAINER_TAG=1.22.1
 # https://hub.docker.com/_/traefik
 TRAEFIK_TAG=1.7.18-alpine
-# https://hub.docker.com/r/docksal/ssh-agent
-SSH_AGENT_TAG=1.3
+# https://hub.docker.com/r/liip/ssh-agent
+SSH_AGENT_TAG=1.0.0
 # https://hub.docker.com/r/liip/ssl-keygen
 SSL_KEYGEN_TAG=1.0.0

--- a/containers/docker-compose.ssh-agent.yml
+++ b/containers/docker-compose.ssh-agent.yml
@@ -2,12 +2,29 @@ version: '3.5'
 services:
 
   sshagent:
-    image: docksal/ssh-agent:$SSH_AGENT_TAG
+    image: liip/ssh-agent:$SSH_AGENT_TAG
     container_name: pontsun_sshagent
     restart: unless-stopped
     volumes:
       - socket_dir:/.ssh-agent
+      - sshkeys_dir:/.ssh-keys
+
+  sshkeys:
+    image: liip/ssh-agent:$SSH_AGENT_TAG
+    container_name: pontsun_sshadd
+    depends_on:
+      - sshagent
+    command:
+      - ssh-key
+      - load
+    environment:
+      SSH_AUTH_SOCK: /.ssh-agent/proxy-socket
+    volumes:
+      - socket_dir:/.ssh-agent
+      - sshkeys_dir:/.ssh-keys
 
 volumes:
   socket_dir:
     name: pontsun_sshagent_socket_dir
+  sshkeys_dir:
+    name: pontsun_sshagent_sshkeys_dir

--- a/containers/docker-compose.ssh-agent.yml
+++ b/containers/docker-compose.ssh-agent.yml
@@ -11,7 +11,7 @@ services:
 
   sshkeys:
     image: liip/ssh-agent:$SSH_AGENT_TAG
-    container_name: pontsun_sshadd
+    container_name: pontsun_sshkeys
     depends_on:
       - sshagent
     command:


### PR DESCRIPTION
It proposes to use a custom SSH agent container that will persist keys to load them on startup.

External resources:
- [SSH agent dockerhub page](https://hub.docker.com/r/liip/ssh-agent)
- [SSH agent github repository](https://github.com/liip/docker-ssh-agent)