### PR TITLE
portainer: bump to latest non-2.0 version

### DIFF
--- a/containers/.env.example
+++ b/containers/.env.example
@@ -14,7 +14,7 @@ PONTSUN_NETWORK=pontsun
 ### Images tags
 
 # https://hub.docker.com/r/portainer/portainer
-PORTAINER_TAG=1.22.1
+PORTAINER_TAG=1.25.1-alpine
 # https://hub.docker.com/_/traefik
 TRAEFIK_TAG=2.8
 # https://hub.docker.com/r/docksal/ssh-agent


### PR DESCRIPTION
2.0 removed authentication disabling; so stick to 1.*