### PR TITLE
Fix portainer-ce: no-auth is not supported, set a default password

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project will help you to:
 
 * Access docker containers via [Traefik](https://traefik.io/): reverse proxy and load balancer for containers
 * Manage and inspect docker via [Portainer](https://www.portainer.io/)
+  *  using user `admin` and password `1234567891011`.
 
 ## Prerequisite
 

--- a/containers/.env.example
+++ b/containers/.env.example
@@ -22,3 +22,6 @@ TRAEFIK_TAG=1.7.34-alpine
 SSH_AGENT_TAG=1.4
 # https://hub.docker.com/r/liip/ssl-keygen
 SSL_KEYGEN_TAG=1.0.0
+
+# 1234567891011 => docker run --rm httpd:latest htpasswd -nbB admin '1234567891011' | cut -d ":" -f 2 | sed 's/\$/\$\$/g'
+PORTAINERCE_ADMIN_PASSWORD=$$2y$$05$$jCVmBOrDZVqq2puWIwjYSOfuzNEmd1w6pSBrLB0tg9Wgyel.kdhwS

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -33,10 +33,10 @@ services:
       - pontsun
 
   portainer:
-    image: portainer/portainer-ce:$PORTAINERCE_TAG
+    image: portainer/portainer-ce:${PORTAINERCE_TAG}
     container_name: pontsun_portainer
     restart: unless-stopped
-    command: --no-auth -H unix:///var/run/docker.sock
+    command: -H unix:///var/run/docker.sock --admin-password '${PORTAINERCE_ADMIN_PASSWORD}'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:


### PR DESCRIPTION
As `--no-auth` is not supported anymore, set a default password.