### PR TITLE
Prevent Docker from parsing variables in .env

### DIFF
--- a/containers/.env.example
+++ b/containers/.env.example
@@ -23,4 +23,4 @@ SSH_AGENT_TAG=1.4
 SSL_KEYGEN_TAG=1.0.0
 
 # 1234567891011 => docker run --rm httpd:latest htpasswd -nbB admin '1234567891011' | head -n1 | cut -d ":" -f 2 | sed 's/^/"/;s/$/"/g'
-PORTAINERCE_ADMIN_PASSWORD="$2y$05$bS2e0Mg6Hg5NekuMausSwelLMtOdc1lUwHg/iWvrHL3MnQSJ8JyDe"
+PORTAINERCE_ADMIN_PASSWORD='$2y$05$bS2e0Mg6Hg5NekuMausSwelLMtOdc1lUwHg/iWvrHL3MnQSJ8JyDe'


### PR DESCRIPTION
Currently, when running Docker commands in the container repository, it triggers the following warnings:

> WARN[0000] The "bS2e0Mg6Hg5NekuMausSwelLMtOdc1lUwHg" variable is not set. Defaulting to a blank string.

This is because it tries to parse the `.env` for variables (starting with `$`).

Using single quotes prevents this.