### PR TITLE
Allow wildcard certificates *.docker.test

### DIFF
--- a/config/pontsun.yml
+++ b/config/pontsun.yml
@@ -8,5 +8,5 @@ tls:
   stores:
     default:
       defaultCertificate:
-        certFile: /certs/docker.test.crt
-        keyFile: /certs/docker.test.key
+        certFile: /certs/wildcard.docker.test.crt
+        keyFile: /certs/wildcard.docker.test.key

--- a/containers/.env
+++ b/containers/.env
@@ -20,7 +20,7 @@ TRAEFIK_TAG=2.8
 # https://hub.docker.com/r/docksal/ssh-agent
 SSH_AGENT_TAG=1.4
 # https://hub.docker.com/r/liip/ssl-keygen
-SSL_KEYGEN_TAG=1.0.0
+SSL_KEYGEN_TAG=wildcard
 
 # 1234567891011 => docker run --rm httpd:latest htpasswd -nbB admin '1234567891011' | head -n1 | cut -d ":" -f 2 | sed 's/^/"/;s/$/"/g'
 PORTAINERCE_ADMIN_PASSWORD='$2y$05$bS2e0Mg6Hg5NekuMausSwelLMtOdc1lUwHg/iWvrHL3MnQSJ8JyDe'

--- a/containers/docker-compose.certificates.yml
+++ b/containers/docker-compose.certificates.yml
@@ -2,7 +2,7 @@ version: '3.5'
 services:
 
   sslkeygen:
-      image: liip/ssl-keygen:$SSL_KEYGEN_TAG
+      image: docker.gitlab.liip.ch/docker/ssl-keygen:$SSL_KEYGEN_TAG
       container_name: pontsun_sslkeygen
       command: ls
       environment:
@@ -12,7 +12,7 @@ services:
           OPENSSL_CERTIFICATE_SUBJECT_LOCATION: Fribourg
           OPENSSL_CERTIFICATE_SUBJECT_ORGANIZATION: Liip
           OPENSSL_CERTIFICATE_SUBJECT_ORGANIZATION_UNIT: Pontsun
-          SITE_DOMAIN: $PROJECT_DOMAIN
+          SITE_DOMAIN: "*.${PROJECT_DOMAIN}"
       volumes:
           - ../certificates/:/certificates:rw
       user: $USER_ID


### PR DESCRIPTION
Todo:

- [ ] Test the feature (you need to generate the certificate according to doc and add `wildcard.docker.test.crt` in your browser truststore)
- [ ] review the internal MR for the certificate generator <https://gitlab.liip.ch/docker/ssl-keygen/-/merge_requests/1>
- [ ] merge it and tag a new release `1.1.0`
- [ ] publish the result on <https://hub.docker.com/r/liip/ssl-keygen>
- [ ] Revert image path on  [docker-compose.certificates.yml](containers/docker-compose.certificates.yml)
- [ ] Adapt `SSL_KEYGEN_TAG=1.1.0` on [.env](.env) file